### PR TITLE
Create full landing layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,32 @@
 'use client'
 
 import { Hero } from '@/components/hero'
-import { Features } from '@/components/features'
-import { ProductGrid } from '@/components/product-grid'
+import { AlreadyInsured } from '@/components/already-insured'
+import { HowItWorks, Differentials } from '@/components/features'
 import { Testimonials } from '@/components/testimonials'
+import { WhyWrong } from '@/components/why-wrong'
+import { Consultoria } from '@/components/consultoria'
+import { ProductGrid } from '@/components/product-grid'
+import { WhyChoose } from '@/components/why-choose'
+import { PaperQuestion } from '@/components/paper-question'
 import { Faq } from '@/components/faq'
+import { ContactSection } from '@/components/contact-section'
 
 export default function Home() {
   return (
     <main className="space-y-16">
       <Hero />
-      <Features />
-      <ProductGrid />
+      <AlreadyInsured />
+      <HowItWorks />
+      <Differentials />
       <Testimonials />
+      <WhyWrong />
+      <Consultoria />
+      <ProductGrid />
+      <WhyChoose />
+      <PaperQuestion />
       <Faq />
+      <ContactSection />
     </main>
   )
 }

--- a/components/already-insured.tsx
+++ b/components/already-insured.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import { motion } from 'framer-motion'
+
+export function AlreadyInsured() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 grid md:grid-cols-2 gap-8 items-center"
+    >
+      <div className="space-y-4">
+        <h2 className="text-3xl font-bold">Você já tem um seguro?</h2>
+        <p className="text-lg">Dimarzio Seguros há 20 anos ajudando mais de 10 mil clientes a proteger o que importa.</p>
+        <Button className="primary-button">Quero minha análise gratuita</Button>
+      </div>
+      <div className="flex justify-center">
+        <Image src="/placeholder.jpg" alt="Pessoa analisando documentos" width={500} height={400} className="rounded-xl shadow" />
+      </div>
+    </motion.section>
+  )
+}

--- a/components/consultoria.tsx
+++ b/components/consultoria.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { CheckCircle } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+const itens = [
+  'Diagnóstico completo da sua situação',
+  'Comparativo de coberturas e preços',
+  'Recomendações personalizadas'
+]
+
+export function Consultoria() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8"
+    >
+      <h2 className="text-3xl font-bold text-center">O que você leva da consultoria gratuita</h2>
+      <ul className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {itens.map((item, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <CheckCircle className="text-secondary mt-1" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="text-center italic">Já ajudamos mais de 10.000 pessoas a contratarem melhor.</div>
+    </motion.section>
+  )
+}

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Mail, MapPin, Phone, Instagram } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export function ContactSection() {
+  return (
+    <motion.section
+      id="contato"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-4 text-center"
+    >
+      <h2 className="text-3xl font-bold">Contato</h2>
+      <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-6 justify-center">
+        <div className="flex flex-col items-center gap-2">
+          <MapPin className="text-secondary" />
+          <span className="text-sm">Rua Cumaru, 219 - sala 16, Campinas - SP</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Phone className="text-secondary" />
+          <span className="text-sm">(19) 3294-0655</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Mail className="text-secondary" />
+          <span className="text-sm">contato@dimarzioseguros.com.br</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Instagram className="text-secondary" />
+          <a href="https://www.instagram.com/dimarzioseguros/" target="_blank" rel="noopener noreferrer" className="underline text-sm">Instagram</a>
+        </div>
+      </div>
+    </motion.section>
+  )
+}

--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -20,7 +20,7 @@ export function Faq() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="container py-16 space-y-8"
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8"
     >
       <h2 className="text-3xl font-bold text-center">Perguntas Frequentes</h2>
       <Accordion type="single" collapsible className="mx-auto max-w-2xl">

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -18,43 +18,47 @@ const differentials = [
   'Atendimento 24 horas'
 ]
 
-export function Features() {
+export function HowItWorks() {
   return (
-    <section className="space-y-16 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.6 }}
-        className="container text-center space-y-8"
-      >
-        <h2 className="text-3xl font-bold">Como funciona na prática</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
-          {steps.map((step, i) => (
-            <div key={i} className="p-4 bg-white rounded-2xl shadow card-hover flex flex-col items-center text-center space-y-2">
-              <step.icon className="w-8 h-8 text-secondary" />
-              <p>{step.text}</p>
-            </div>
-          ))}
-        </div>
-      </motion.div>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.6 }}
-        className="container text-center space-y-8 bg-gray-50 py-12 rounded-2xl"
-      >
-        <h2 className="text-3xl font-bold">O que faz a Dimarzio diferente</h2>
-        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 text-left">
-          {differentials.map((d, i) => (
-            <li key={i} className="flex items-start gap-2">
-              <Star className="w-5 h-5 text-secondary mt-1" />
-              <span>{d}</span>
-            </li>
-          ))}
-        </ul>
-      </motion.div>
-    </section>
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 text-center space-y-8"
+    >
+      <h2 className="text-3xl font-bold">Como funciona na prática</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+        {steps.map((step, i) => (
+          <div key={i} className="p-4 bg-white rounded-2xl shadow card-hover flex flex-col items-center text-center space-y-2">
+            <step.icon className="w-8 h-8 text-secondary" />
+            <p>{step.text}</p>
+          </div>
+        ))}
+      </div>
+    </motion.section>
+  )
+}
+
+export function Differentials() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 text-center space-y-8 bg-gray-50 rounded-2xl"
+    >
+      <h2 className="text-3xl font-bold">O que faz a Dimarzio diferente</h2>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 text-left">
+        {differentials.map((d, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <Star className="w-5 h-5 text-secondary mt-1" />
+            <span>{d}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="border p-4 italic rounded-md max-w-2xl mx-auto">“Você fala com quem resolve…”</div>
+    </motion.section>
   )
 }

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { BadgeCheck } from 'lucide-react'
 import { motion } from 'framer-motion'
@@ -10,14 +11,21 @@ export function Hero() {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
-      className="relative w-full text-center py-24 px-4 bg-gradient-to-br from-primary to-secondary text-white"
+      className="relative w-full py-24 bg-gradient-to-br from-purple-50 to-blue-50"
     >
-      <h1 className="text-4xl md:text-6xl font-bold mb-4">Dimarzio Seguros</h1>
-      <p className="text-lg md:text-2xl mb-8">20 anos protegendo com clareza</p>
-      <Button className="primary-button text-base md:text-lg px-8 py-4 rounded-full">Quero minha análise gratuita</Button>
-      <div className="flex justify-center gap-6 mt-8 text-sm">
-        <span className="flex items-center gap-2"><BadgeCheck className="text-secondary" />Atendimento 24h</span>
-        <span className="flex items-center gap-2"><BadgeCheck className="text-secondary" />+10k clientes</span>
+      <div className="mx-auto max-w-screen-xl px-4 md:px-8 grid md:grid-cols-2 gap-8 items-center">
+        <div className="text-center md:text-left space-y-6">
+          <h1 className="text-4xl md:text-6xl font-bold">Dimarzio Seguros — 20 anos protegendo com clareza</h1>
+          <p className="text-lg">Seguros pensados para você e sua família.</p>
+          <Button className="primary-button text-base md:text-lg px-8 py-4 rounded-full">Quero minha análise gratuita</Button>
+          <div className="flex justify-center md:justify-start gap-6 text-sm mt-4">
+            <span className="flex items-center gap-2"><BadgeCheck className="text-secondary" />Atendimento 24h</span>
+            <span className="flex items-center gap-2"><BadgeCheck className="text-secondary" />+10k clientes</span>
+          </div>
+        </div>
+        <div className="hidden md:block">
+          <Image src="/placeholder.jpg" alt="Família protegida" width={500} height={400} className="rounded-xl shadow" />
+        </div>
       </div>
     </motion.section>
   )

--- a/components/paper-question.tsx
+++ b/components/paper-question.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Button } from '@/components/ui/button'
+
+export function PaperQuestion() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="py-16 bg-gray-100 mx-auto max-w-screen-xl px-4 md:px-8 text-center space-y-4"
+    >
+      <h2 className="text-3xl font-bold">Seu seguro protege ou é só papel?</h2>
+      <p className="text-lg">Não fique na dúvida. Revise suas coberturas agora mesmo.</p>
+      <Button className="primary-button">Falar no WhatsApp</Button>
+    </motion.section>
+  )
+}

--- a/components/product-grid.tsx
+++ b/components/product-grid.tsx
@@ -13,13 +13,12 @@ export function ProductGrid() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="container py-16 space-y-8 text-center"
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8 text-center"
     >
-      <h2 className="text-3xl font-bold">Produtos oferecidos</h2>
+      <h2 className="text-3xl font-bold">Qual seguro você quer entender melhor?</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         {products.map((p) => (
-          <Link key={p.slug} href={`/produtos/${p.slug}`}
-            className="block">
+          <Link key={p.slug} href={`/produtos/${p.slug}`} className="block">
             <Card className="shadow card-hover h-full">
               <CardContent className="p-6 flex flex-col items-center gap-2">
                 <span className="font-semibold text-lg">{p.title}</span>

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -22,7 +22,7 @@ export function Testimonials() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="container py-16 space-y-8 text-center"
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8 text-center"
     >
       <h2 className="text-3xl font-bold">O que nossos clientes dizem</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/components/why-choose.tsx
+++ b/components/why-choose.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Check } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+const benefits = [
+  'Atendimento humanizado e rápido',
+  'Parceria com as principais seguradoras',
+  'Equipe especializada em sinistros'
+]
+
+export function WhyChoose() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="py-16 bg-gray-50 mx-auto max-w-screen-xl px-4 md:px-8 space-y-8"
+    >
+      <h2 className="text-3xl font-bold text-center">Por que escolher a Dimarzio?</h2>
+      <ul className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {benefits.map((b, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <Check className="text-secondary mt-1" />
+            <span>{b}</span>
+          </li>
+        ))}
+      </ul>
+    </motion.section>
+  )
+}

--- a/components/why-wrong.tsx
+++ b/components/why-wrong.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export function WhyWrong() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+      className="py-16 px-4 md:px-8 bg-red-50 text-center mx-auto max-w-screen-xl space-y-4"
+    >
+      <h2 className="text-3xl font-bold">Por que tanta gente contrata errado?</h2>
+      <p className="text-lg max-w-2xl mx-auto flex justify-center items-center gap-2"><AlertTriangle className="text-secondary" />Muitos sinistros são negados por falta de orientação adequada.</p>
+    </motion.section>
+  )
+}


### PR DESCRIPTION
## Summary
- build hero section with gradient and hero image
- add "Você já tem um seguro" encouragement
- split features into HowItWorks and Differentials with citation
- show testimonials in container
- add warning section about wrong contracts
- list consultoria benefits
- tweak product grid heading
- list reasons to choose Dimarzio
- add emotional paper question section
- display FAQ
- include contact section at the end

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845d58e57dc832e82904535400d27c7