### PR TITLE
Landing page redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Dimarzio Seguros Landing Page
+
+Esta é a segunda versão da landing page da Dimarzio Seguros construída com Next.js, Tailwind e shadcn/ui.
+
+## Trocar imagens placeholder
+
+1. Substitua os arquivos na pasta `public/` mantendo os mesmos nomes (`placeholder.jpg`, etc.).
+2. Ou edite os componentes correspondentes e altere o caminho das imagens em `<Image src="..." />`.
+
+Após alterar, execute `npm run build` para gerar a versão estática.

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,9 +49,9 @@ body {
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 248 50% 35%; /* Roxo Dimarzio */
+    --primary: 221 62% 33%; /* Azul escuro */
     --primary-foreground: 0 0% 98%;
-    --secondary: 335 92% 47%; /* Rosa Dimarzio */
+    --secondary: 220 82% 56%;
     --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
@@ -79,9 +79,9 @@ body {
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 248 50% 35%;
+    --primary: 221 62% 33%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 335 92% 47%;
+    --secondary: 220 82% 56%;
     --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;
@@ -141,7 +141,7 @@ body {
 
 /* Personalização de elementos */
 .primary-button {
-  @apply bg-gradient-to-r from-[#3A2D87] to-[#E50964] hover:from-[#2e236c] hover:to-[#c10756] text-white transition-all duration-300 ease-in-out transform hover:shadow-lg;
+  @apply bg-gradient-to-r from-[#2563EB] to-[#1E3A8A] text-white transition-all duration-300 ease-in-out hover:brightness-110 hover:shadow-lg;
 }
 
 .card-hover {
@@ -149,9 +149,9 @@ body {
 }
 
 :root {
-  --primary: #3A2D87;
-  --primary-light: #5b45b8;
-  --primary-dark: #2e236c;
+  --primary: #1E3A8A;
+  --primary-light: #2563EB;
+  --primary-dark: #1E3A8A;
 }
 
 @layer base {
@@ -170,7 +170,7 @@ body {
   }
 
   .primary-button {
-    @apply bg-[#3A2D87] text-white hover:bg-[#2e236c] transition-colors;
+    @apply bg-[#1E3A8A] text-white hover:bg-[#2563EB] transition-colors;
   }
 
   .gradient-text {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Navbar } from "@/components/navbar"
 import { Footer } from "@/components/footer"
-import { WhatsappButton } from "@/components/whatsapp-button"
+import { FloatingWhatsAppButton } from "@/components/floating-whatsapp-button"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -26,7 +26,7 @@ export default function RootLayout({
           <Navbar />
           <div className="pt-16">{children}</div>
           <Footer />
-          <WhatsappButton />
+          <FloatingWhatsAppButton />
         </ThemeProvider>
       </body>
     </html>

--- a/components/already-insured.tsx
+++ b/components/already-insured.tsx
@@ -11,7 +11,7 @@ export function AlreadyInsured() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 grid md:grid-cols-2 gap-8 items-center"
+      className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 grid md:grid-cols-2 gap-8 items-center bg-blue-50 rounded-2xl"
     >
       <div className="space-y-4">
         <h2 className="text-3xl font-bold">Você já tem um seguro?</h2>
@@ -19,7 +19,7 @@ export function AlreadyInsured() {
         <Button className="primary-button">Quero minha análise gratuita</Button>
       </div>
       <div className="flex justify-center">
-        <Image src="/placeholder.jpg" alt="Pessoa analisando documentos" width={500} height={400} className="rounded-xl shadow" />
+        <Image src="/placeholder.jpg" alt="Pessoa analisando documentos" width={500} height={400} className="rounded-xl shadow-lg" />
       </div>
     </motion.section>
   )

--- a/components/consultoria.tsx
+++ b/components/consultoria.tsx
@@ -19,10 +19,10 @@ export function Consultoria() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8"
     >
       <h2 className="text-3xl font-bold text-center">O que você leva da consultoria gratuita</h2>
-      <ul className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <ul className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {itens.map((item, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <CheckCircle className="text-secondary mt-1" />
+          <li key={i} className="flex items-center gap-3 p-4 border-l-4 border-blue-600 bg-white rounded-md shadow">
+            <CheckCircle className="text-blue-600" />
             <span>{item}</span>
           </li>
         ))}

--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -23,7 +23,7 @@ export function Faq() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8"
     >
       <h2 className="text-3xl font-bold text-center">Perguntas Frequentes</h2>
-      <Accordion type="single" collapsible className="mx-auto max-w-2xl">
+      <Accordion type="single" collapsible className="mx-auto max-w-2xl space-y-4">
         {faqs.map((item, idx) => (
           <AccordionItem key={idx} value={`item-${idx}`}>
             <AccordionTrigger>{item.q}</AccordionTrigger>

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -28,12 +28,21 @@ export function HowItWorks() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 text-center space-y-8"
     >
       <h2 className="text-3xl font-bold">Como funciona na prática</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+      <div className="flex flex-col md:flex-row gap-6">
         {steps.map((step, i) => (
-          <div key={i} className="p-4 bg-white rounded-2xl shadow card-hover flex flex-col items-center text-center space-y-2">
-            <step.icon className="w-8 h-8 text-secondary" />
-            <p>{step.text}</p>
-          </div>
+          <motion.div
+            key={i}
+            className="flex-1 bg-white rounded-xl shadow p-4 flex items-center gap-4"
+            whileHover={{ scale: 1.02 }}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+          >
+            <div className="bg-blue-100 text-blue-700 rounded-full p-2">
+              <step.icon className="w-6 h-6" />
+            </div>
+            <p className="text-left">{step.text}</p>
+          </motion.div>
         ))}
       </div>
     </motion.section>
@@ -50,15 +59,17 @@ export function Differentials() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 text-center space-y-8 bg-gray-50 rounded-2xl"
     >
       <h2 className="text-3xl font-bold">O que faz a Dimarzio diferente</h2>
-      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 text-left">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         {differentials.map((d, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <Star className="w-5 h-5 text-secondary mt-1" />
+          <div key={i} className="p-4 bg-white rounded-xl shadow hover:shadow-lg transition-all flex flex-col items-center text-center gap-2">
+            <div className="bg-white rounded-xl p-3 shadow mb-2">
+              <Star className="w-6 h-6 text-blue-600" />
+            </div>
             <span>{d}</span>
-          </li>
+          </div>
         ))}
-      </ul>
-      <div className="border p-4 italic rounded-md max-w-2xl mx-auto">“Você fala com quem resolve…”</div>
+      </div>
+      <div className="p-4 italic rounded-md border max-w-2xl mx-auto">“Você fala com quem resolve…”</div>
     </motion.section>
   )
 }

--- a/components/floating-whatsapp-button.tsx
+++ b/components/floating-whatsapp-button.tsx
@@ -1,13 +1,13 @@
 'use client'
-
 import { MessageCircle } from 'lucide-react'
 
-export function WhatsappButton() {
+export function FloatingWhatsAppButton() {
   return (
     <a
       href="https://wa.me/551932940655"
       target="_blank"
       rel="noopener noreferrer"
+      aria-label="WhatsApp"
       className="fixed bottom-4 right-4 bg-[#25D366] text-white p-4 rounded-full shadow-lg hover:scale-105 transition-transform"
     >
       <MessageCircle className="w-6 h-6" />

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,14 +3,20 @@ import Link from 'next/link'
 
 export function Footer() {
   return (
-    <footer className="bg-gray-100 mt-16">
-      <div className="container py-10 text-center space-y-4">
-        <div className="flex justify-center">
+    <footer className="bg-blue-700 text-white mt-16 border-t border-blue-600">
+      <div className="container py-10 grid md:grid-cols-3 gap-8 text-sm">
+        <div className="flex flex-col items-center md:items-start gap-2">
           <Image src="/logo.svg" alt="Dimarzio Seguros" width={40} height={40} />
+          <span className="font-medium">Dimarzio Seguros</span>
+          <span>20 anos protegendo com clareza</span>
         </div>
-        <p className="font-medium">Dimarzio Seguros — 20 anos protegendo com clareza</p>
-        <address className="not-italic space-y-1 text-sm">
-          <div>Rua Cumaru, 219 - sala 16, Edifício Laser, Alphaville, Campinas - SP, 13098-324</div>
+        <nav className="flex flex-col items-center md:items-start gap-1">
+          <Link href="/">Home</Link>
+          <Link href="/#seguros">Produtos</Link>
+          <Link href="/contato">Contato</Link>
+        </nav>
+        <address className="not-italic space-y-1 text-center md:text-left">
+          <div>Rua Cumaru, 219 - sala 16, Campinas - SP</div>
           <div>(19) 3294-0655</div>
           <div>
             <a href="mailto:contato@dimarzioseguros.com.br" className="underline">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { BadgeCheck } from 'lucide-react'
 import { motion } from 'framer-motion'
+import { SectionDivider } from './section-divider'
 
 export function Hero() {
   return (
@@ -11,12 +12,13 @@ export function Hero() {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6 }}
-      className="relative w-full py-24 bg-gradient-to-br from-purple-50 to-blue-50"
+      className="relative w-full py-24 bg-gradient-to-br from-blue-700 to-blue-100 text-white"
     >
-      <div className="mx-auto max-w-screen-xl px-4 md:px-8 grid md:grid-cols-2 gap-8 items-center">
+      <div className="mx-auto max-w-screen-xl px-4 md:px-8 grid md:grid-cols-2 gap-8 items-center relative">
+        <span className="absolute -top-4 left-4 bg-blue-600 text-white text-xs px-3 py-1 rounded-full shadow">20 anos</span>
         <div className="text-center md:text-left space-y-6">
-          <h1 className="text-4xl md:text-6xl font-bold">Dimarzio Seguros — 20 anos protegendo com clareza</h1>
-          <p className="text-lg">Seguros pensados para você e sua família.</p>
+          <h1 className="text-4xl md:text-6xl font-bold text-white">Dimarzio Seguros — 20 anos protegendo com clareza</h1>
+          <p className="text-lg text-blue-100">Seguros pensados para você e sua família.</p>
           <Button className="primary-button text-base md:text-lg px-8 py-4 rounded-full">Quero minha análise gratuita</Button>
           <div className="flex justify-center md:justify-start gap-6 text-sm mt-4">
             <span className="flex items-center gap-2"><BadgeCheck className="text-secondary" />Atendimento 24h</span>
@@ -27,6 +29,7 @@ export function Hero() {
           <Image src="/placeholder.jpg" alt="Família protegida" width={500} height={400} className="rounded-xl shadow" />
         </div>
       </div>
+      <SectionDivider className="text-white" />
     </motion.section>
   )
 }

--- a/components/paper-question.tsx
+++ b/components/paper-question.tsx
@@ -10,11 +10,14 @@ export function PaperQuestion() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="py-16 bg-gray-100 mx-auto max-w-screen-xl px-4 md:px-8 text-center space-y-4"
+      className="py-16 bg-gradient-to-br from-blue-100 to-white mx-auto max-w-screen-xl px-4 md:px-8 text-center space-y-4"
     >
       <h2 className="text-3xl font-bold">Seu seguro protege ou é só papel?</h2>
-      <p className="text-lg">Não fique na dúvida. Revise suas coberturas agora mesmo.</p>
-      <Button className="primary-button">Falar no WhatsApp</Button>
+      <p className="text-lg text-gray-700">Não fique na dúvida. Revise suas coberturas agora mesmo.</p>
+      <div className="flex flex-col sm:flex-row justify-center gap-4">
+        <Button className="primary-button px-6 py-3">Agendar análise</Button>
+        <Button variant="outline" className="px-6 py-3 border-blue-600 text-blue-600 hover:bg-blue-50">WhatsApp</Button>
+      </div>
     </motion.section>
   )
 }

--- a/components/product-card.tsx
+++ b/components/product-card.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { LucideIcon } from 'lucide-react'
+
+interface ProductCardProps {
+  icon: LucideIcon
+  title: string
+  slug: string
+  description?: string
+  className?: string
+}
+
+export function ProductCard({ icon: Icon, title, slug, description, className }: ProductCardProps) {
+  return (
+    <Link href={`/produtos/${slug}`} className={cn('block group', className)} prefetch>
+      <Card className="h-full transition-all hover:-translate-y-2 hover:ring-2 hover:ring-blue-600">
+        <CardContent className="p-6 flex flex-col items-center gap-3 text-center">
+          <Icon className="w-8 h-8 text-blue-600" aria-hidden="true" />
+          <span className="font-semibold text-lg">{title}</span>
+          {description && <p className="text-sm text-gray-600">{description}</p>}
+          <Button variant="outline" size="sm" className="mt-2">Saiba mais</Button>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/components/product-filter-tabs.tsx
+++ b/components/product-filter-tabs.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface ProductFilterTabsProps {
+  filters: string[]
+  active: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+export function ProductFilterTabs({ filters, active, onChange, className }: ProductFilterTabsProps) {
+  return (
+    <div className={cn('flex flex-wrap justify-center gap-2', className)}>
+      {filters.map((f) => (
+        <Button
+          key={f}
+          onClick={() => onChange(f)}
+          variant={active === f ? 'default' : 'outline'}
+          className="rounded-full px-4 py-2 text-sm"
+        >
+          {f}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/components/product-grid.tsx
+++ b/components/product-grid.tsx
@@ -1,11 +1,43 @@
 'use client'
 
-import Link from 'next/link'
-import { products } from '@/lib/products'
-import { Card, CardContent } from '@/components/ui/card'
+import { products, type Product } from '@/lib/products'
+import { ProductFilterTabs } from './product-filter-tabs'
+import { ProductCard } from './product-card'
+import {
+  Car,
+  Home,
+  Plane,
+  Briefcase,
+  Handshake,
+  HeartPulse,
+  PiggyBank,
+  ShieldCheck,
+  Laptop,
+  HandCoins,
+  Tractor,
+} from 'lucide-react'
 import { motion } from 'framer-motion'
+import { useState } from 'react'
+
+const icons: Record<string, any> = {
+  consorcio: PiggyBank,
+  saude: HeartPulse,
+  vida: Handshake,
+  empresarial: Briefcase,
+  automovel: Car,
+  residencial: Home,
+  viagem: Plane,
+  'rc-profissional': ShieldCheck,
+  rural: Tractor,
+  'fianca-locaticia': HandCoins,
+  portateis: Laptop,
+  fiduciario: Briefcase,
+}
 
 export function ProductGrid() {
+  const [filter, setFilter] = useState('Todos')
+  const filters = ['Todos', 'Empresariais', 'Pessoais']
+  const filtered = products.filter((p) => filter === 'Todos' || p.category === filter)
   return (
     <motion.section
       id="seguros"
@@ -16,16 +48,12 @@ export function ProductGrid() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8 text-center"
     >
       <h2 className="text-3xl font-bold">Qual seguro você quer entender melhor?</h2>
+      <ProductFilterTabs filters={filters} active={filter} onChange={setFilter} />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {products.map((p) => (
-          <Link key={p.slug} href={`/produtos/${p.slug}`} className="block">
-            <Card className="shadow card-hover h-full">
-              <CardContent className="p-6 flex flex-col items-center gap-2">
-                <span className="font-semibold text-lg">{p.title}</span>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+        {filtered.map((p) => {
+          const Icon = icons[p.slug]
+          return <ProductCard key={p.slug} slug={p.slug} title={p.title} icon={Icon} />
+        })}
       </div>
     </motion.section>
   )

--- a/components/section-divider.tsx
+++ b/components/section-divider.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils'
+
+interface Props {
+  className?: string
+}
+
+export function SectionDivider({ className }: Props) {
+  return (
+    <svg viewBox="0 0 1440 80" className={cn('w-full h-10 md:h-16', className)} preserveAspectRatio="none">
+      <path
+        d="M0 40c120-40 240 40 360 40s240-80 360-80 240 80 360 80 240-40 360-40v80H0z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/components/testimonial-slider.tsx
+++ b/components/testimonial-slider.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useRef } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import Autoplay from 'embla-carousel-autoplay'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface Testimonial {
+  text: string
+  author: string
+}
+
+interface TestimonialSliderProps {
+  testimonials: Testimonial[]
+}
+
+export function TestimonialSlider({ testimonials }: TestimonialSliderProps) {
+  const autoplay = useRef(
+    Autoplay({ delay: 4000, stopOnInteraction: true, stopOnMouseEnter: true })
+  )
+  const [emblaRef] = useEmblaCarousel({ loop: true }, [autoplay.current])
+
+  return (
+    <div className="overflow-hidden" ref={emblaRef}>
+      <div className="flex gap-4">
+        {testimonials.map((t, i) => (
+          <Card key={i} className="min-w-full sm:min-w-[50%] bg-blue-50">
+            <CardContent className="p-6 space-y-4">
+              <p className="text-base italic text-gray-700">“{t.text}”</p>
+              <p className="text-sm font-medium">{t.author}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Card, CardContent } from '@/components/ui/card'
+import { TestimonialSlider } from './testimonial-slider'
 
 const testimonials = [
   {
@@ -25,16 +25,7 @@ export function Testimonials() {
       className="mx-auto max-w-screen-xl px-4 md:px-8 py-16 space-y-8 text-center"
     >
       <h2 className="text-3xl font-bold">O que nossos clientes dizem</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {testimonials.map((t, i) => (
-          <Card key={i} className="bg-gray-50 shadow-sm">
-            <CardContent className="p-6 space-y-4">
-              <p className="text-lg italic">“{t.text}”</p>
-              <p className="text-sm font-medium">{t.author}</p>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <TestimonialSlider testimonials={testimonials} />
     </motion.section>
   )
 }

--- a/components/why-choose.tsx
+++ b/components/why-choose.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Check } from 'lucide-react'
+import Image from 'next/image'
 import { motion } from 'framer-motion'
 
 const benefits = [
@@ -16,17 +17,22 @@ export function WhyChoose() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="py-16 bg-gray-50 mx-auto max-w-screen-xl px-4 md:px-8 space-y-8"
+      className="py-16 bg-gray-50 mx-auto max-w-screen-xl px-4 md:px-8"
     >
-      <h2 className="text-3xl font-bold text-center">Por que escolher a Dimarzio?</h2>
-      <ul className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
-        {benefits.map((b, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <Check className="text-secondary mt-1" />
-            <span>{b}</span>
-          </li>
-        ))}
-      </ul>
+      <h2 className="text-3xl font-bold text-center mb-8">Por que escolher a Dimarzio?</h2>
+      <div className="grid md:grid-cols-2 gap-8 items-center">
+        <ul className="space-y-4">
+          {benefits.map((b, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <Check className="text-blue-600 mt-1" />
+              <span>{b}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-center">
+          <Image src="/placeholder.jpg" alt="Equipe Dimarzio" width={400} height={300} className="rounded-xl shadow" />
+        </div>
+      </div>
     </motion.section>
   )
 }

--- a/components/why-wrong.tsx
+++ b/components/why-wrong.tsx
@@ -10,10 +10,13 @@ export function WhyWrong() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.6 }}
-      className="py-16 px-4 md:px-8 bg-red-50 text-center mx-auto max-w-screen-xl space-y-4"
+      className="py-16 px-4 md:px-8 bg-blue-700 text-white text-center mx-auto max-w-screen-xl space-y-4"
     >
       <h2 className="text-3xl font-bold">Por que tanta gente contrata errado?</h2>
-      <p className="text-lg max-w-2xl mx-auto flex justify-center items-center gap-2"><AlertTriangle className="text-secondary" />Muitos sinistros são negados por falta de orientação adequada.</p>
+      <p className="text-lg max-w-2xl mx-auto flex justify-center items-center gap-2">
+        <span className="bg-blue-600 p-2 rounded-full"><AlertTriangle className="text-white w-5 h-5" /></span>
+        Muitos sinistros são negados por falta de orientação adequada.
+      </p>
     </motion.section>
   )
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -4,10 +4,11 @@ export type Product = {
   description: string
   who: string
   benefits: string[]
+  category: 'Empresariais' | 'Pessoais'
 }
 
 export const products: Product[] = [
-  {
+  { 
     slug: 'consorcio',
     title: 'Consórcio',
     description: 'Compra planejada de bens sem pagamento de juros.',
@@ -16,7 +17,8 @@ export const products: Product[] = [
       'Sem juros, apenas taxa de administração',
       'Planejamento financeiro de longo prazo',
       'Diversas opções de carta de crédito'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'saude',
@@ -27,7 +29,8 @@ export const products: Product[] = [
       'Cobertura nacional',
       'Rede credenciada ampla',
       'Planos personalizados'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'vida',
@@ -38,7 +41,8 @@ export const products: Product[] = [
       'Tranquilidade para a família',
       'Coberturas adicionais de invalidez e doenças graves',
       'Indenização sem burocracia'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'empresarial',
@@ -49,7 +53,8 @@ export const products: Product[] = [
       'Coberturas flexíveis conforme o ramo',
       'Proteção contra incêndio, roubo e responsabilidade civil',
       'Assistência 24 horas'
-    ]
+    ],
+    category: 'Empresariais'
   },
   {
     slug: 'automovel',
@@ -60,7 +65,8 @@ export const products: Product[] = [
       'Cobertura para colisão, roubo e furto',
       'Carro reserva e assistência 24h',
       'Opções com franquia reduzida'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'residencial',
@@ -71,7 +77,8 @@ export const products: Product[] = [
       'Cobertura para incêndio, roubo e danos elétricos',
       'Assistência para pequenos reparos',
       'Planos sob medida'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'viagem',
@@ -82,7 +89,8 @@ export const products: Product[] = [
       'Atendimento 24h em português',
       'Cobertura para extravio de bagagem',
       'Despesas médicas e odontológicas'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'rc-profissional',
@@ -93,7 +101,8 @@ export const products: Product[] = [
       'Ampara processos por erro ou omissão',
       'Resguarda o patrimônio pessoal',
       'Planos específicos por profissão'
-    ]
+    ],
+    category: 'Empresariais'
   },
   {
     slug: 'rural',
@@ -104,7 +113,8 @@ export const products: Product[] = [
       'Ampara perdas por eventos climáticos',
       'Cobertura para máquinas e equipamentos',
       'Auxílio na continuidade da produção'
-    ]
+    ],
+    category: 'Empresariais'
   },
   {
     slug: 'fianca-locaticia',
@@ -115,7 +125,8 @@ export const products: Product[] = [
       'Facilidade na aprovação do aluguel',
       'Garante pagamento ao proprietário',
       'Parcelamento do prêmio'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'portateis',
@@ -126,7 +137,8 @@ export const products: Product[] = [
       'Cobertura contra roubo e danos acidentais',
       'Assistência para reparos',
       'Vigência nacional e internacional'
-    ]
+    ],
+    category: 'Pessoais'
   },
   {
     slug: 'fiduciario',
@@ -137,7 +149,8 @@ export const products: Product[] = [
       'Segurança em contratos de grande valor',
       'Reduz custos de garantias bancárias',
       'Agilidade na emissão da apólice'
-    ]
+    ],
+    category: 'Empresariais'
   }
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
         "date-fns": "3.6.0",
+        "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "8.5.1",
         "framer-motion": "^12.16.0",
         "input-otp": "1.4.1",
@@ -2773,6 +2774,15 @@
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.1.tgz",
       "integrity": "sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==",
       "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/embla-carousel-react": {
       "version": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
     "date-fns": "3.6.0",
+    "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "8.5.1",
     "framer-motion": "^12.16.0",
     "input-otp": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,11 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz"
   integrity sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==
 
+embla-carousel-autoplay@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz"
+  integrity sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==
+
 embla-carousel-react@8.5.1:
   version "8.5.1"
   resolved "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.1.tgz"


### PR DESCRIPTION
## Summary
- add floating WhatsApp button and section divider
- create product card components with filter tabs
- add testimonial slider with autoscroll
- redesign hero, features, product grid and footer
- tweak global palette and typography
- update product data with categories
- docs: how to replace placeholder images

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6845da599be8832eb552e0c41c5383aa